### PR TITLE
Struct .member indexing

### DIFF
--- a/src/lex.rs
+++ b/src/lex.rs
@@ -61,6 +61,7 @@ pub enum Token {
     Import,
     Literally,
     Underscore,
+    Dot,
 
     // strip me before parsing
     Comment(String),
@@ -548,6 +549,7 @@ impl<'a> Lexer<'a> {
                                 self.emit(Token::Ident(acc))
                             }
                             ("", '=') => self.emit(Token::Assign),
+                            ("", '.') => self.emit(Token::Dot),
                             (_, '=') => {
                                 self.emit_but_last(Token::Ident(acc), Token::Assign);
                             }


### PR DESCRIPTION
No idea if you want this in noulith, but :)

The commit:
- removes struct fields as functions
- removes (shadows?) the dot operator
- removes empty struct constructor (why was that a thing?)
- no struct assignment yet (probably don't want that, given that the data structures are all immutable)
